### PR TITLE
Update rlsa

### DIFF
--- a/rlsa
+++ b/rlsa
@@ -8,6 +8,8 @@
 # URL: http://github.com/smajda/todo.actions.d
 
 
+TMP_FILE="$TODO_DIR"/rlsa.tmp
+
 ############# config:
 
 ## 1. list the files you want to show
@@ -47,3 +49,5 @@ do
 done
 
 _list "$TMP_FILE" "$@"
+
+rm $TMP_FILE


### PR DESCRIPTION
Original script breaks if there is not an environment variable set $TMP_FILE

May I suggest specifying a unique temp file and removing it after processing as per above changes.

This would not affect the normal process assuming that the user would not want to keep $TMP_FILE